### PR TITLE
add filter by taxonomy for spectrum

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/spectracluster/util/predicate/spectrum/TaxonomyPredicate.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/util/predicate/spectrum/TaxonomyPredicate.java
@@ -1,0 +1,28 @@
+package uk.ac.ebi.pride.spectracluster.util.predicate.spectrum;
+
+import uk.ac.ebi.pride.spectracluster.spectrum.ISpectrum;
+import uk.ac.ebi.pride.spectracluster.spectrum.KnownProperties;
+import uk.ac.ebi.pride.spectracluster.util.predicate.IPredicate;
+
+/**
+ * Check whether a spectrum is from a given taxonomy or not
+ *
+ * @author Rui Wang
+ * @version $Id$
+ */
+public class TaxonomyPredicate implements IPredicate<ISpectrum> {
+
+    private final String taxonomy;
+
+    public TaxonomyPredicate(String taxonomy) {
+        this.taxonomy = taxonomy;
+    }
+
+    @Override
+    public boolean apply(ISpectrum spectrum) {
+        String tax = spectrum.getProperty(KnownProperties.TAXONOMY_KEY);
+        return tax != null && tax.equals(taxonomy);
+    }
+
+
+}

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/util/predicate/spectrum/UnidentifiedPredicate.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/util/predicate/spectrum/UnidentifiedPredicate.java
@@ -1,0 +1,19 @@
+package uk.ac.ebi.pride.spectracluster.util.predicate.spectrum;
+
+import uk.ac.ebi.pride.spectracluster.spectrum.ISpectrum;
+import uk.ac.ebi.pride.spectracluster.spectrum.KnownProperties;
+import uk.ac.ebi.pride.spectracluster.util.predicate.IPredicate;
+
+/**
+ * Check whether a spectrum is unidentified or not
+ *
+ * @author Rui Wang
+ * @version $Id$
+ */
+public class UnidentifiedPredicate implements IPredicate<ISpectrum> {
+
+    @Override
+    public boolean apply(ISpectrum spectrum) {
+        return spectrum.getProperty(KnownProperties.IDENTIFIED_PEPTIDE_KEY) == null;
+    }
+}


### PR DESCRIPTION
Add two filters for exporting from PRIDE Archive:

1. Filter to keep only unidentified spectra
2. Filter to keep spectra from a given taxonomy