### PR TITLE
Unified the way the fragment ion tolerance is set in ISimilarityCheckerS

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/AllPeaksDotProduct.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/AllPeaksDotProduct.java
@@ -186,4 +186,14 @@ public class AllPeaksDotProduct implements ISimilarityChecker {
     public void setPeakFiltering(boolean peakFiltering) {
 
     }
+
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+
+    }
+
+    @Override
+    public float getFragmentIonTolerance() {
+        return 0;
+    }
 }

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProduct.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProduct.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.pride.spectracluster.similarity;
 
 import uk.ac.ebi.pride.spectracluster.spectrum.IPeak;
 import uk.ac.ebi.pride.spectracluster.spectrum.ISpectrum;
+import uk.ac.ebi.pride.spectracluster.util.Defaults;
 import uk.ac.ebi.pride.spectracluster.util.Pair;
 
 
@@ -26,6 +27,12 @@ public class FrankEtAlDotProduct implements ISimilarityChecker {
     private static final int K2011_BIN_SIZE = 50;
 
     /**
+     * This is the minimum / default number of peaks to compare
+     * as used in the original paper.
+     */
+    public final static int DEFAULT_NUMBER_OF_PEAKS_TO_COMPARE = 15;
+
+    /**
      * If enabled the algorithm only uses the K
      * highest peaks of the spectra.
      */
@@ -43,18 +50,21 @@ public class FrankEtAlDotProduct implements ISimilarityChecker {
 
     public static final AlgorithmVersion DEFAULT_ALGORITHM = AlgorithmVersion.NAT_METH_2011;
 
-    private double peakMzTolerance;
+    private float fragmentIonTolerance;
     private int numberOfPeaksToCompare;
 
-    public FrankEtAlDotProduct(double peakMzTolerance,
+    public FrankEtAlDotProduct(float fragmentIonTolerance,
                                   int numberOfPeaksToCompare) {
-        this.peakMzTolerance = peakMzTolerance;
+        this.fragmentIonTolerance = fragmentIonTolerance;
         this.numberOfPeaksToCompare = numberOfPeaksToCompare;
     }
 
-    public FrankEtAlDotProduct(double peakMzTolerance) {
-        this.peakMzTolerance = peakMzTolerance;
-        this.numberOfPeaksToCompare = 15; // default value set in the paper
+    public FrankEtAlDotProduct(float fragmentIonTolerance) {
+        this(fragmentIonTolerance, DEFAULT_NUMBER_OF_PEAKS_TO_COMPARE);
+    }
+
+    public FrankEtAlDotProduct() {
+        this(Defaults.getFragmentIonTolerance(), DEFAULT_NUMBER_OF_PEAKS_TO_COMPARE);
     }
 
     /**
@@ -133,7 +143,7 @@ public class FrankEtAlDotProduct implements ISimilarityChecker {
             highestPeaksSpectrum2 = spectrum2;
         }
 
-        IPeakMatches peakMatches = PeakMatchesUtilities.getSharedPeaksAsMatches(highestPeaksSpectrum1, highestPeaksSpectrum2, (float) this.peakMzTolerance);
+        IPeakMatches peakMatches = PeakMatchesUtilities.getSharedPeaksAsMatches(highestPeaksSpectrum1, highestPeaksSpectrum2, (float) this.fragmentIonTolerance);
 
         return assessSimilarity(peakMatches);
     }
@@ -224,5 +234,15 @@ public class FrankEtAlDotProduct implements ISimilarityChecker {
 
     public void setPeakFiltering(boolean peakFiltering) {
         this.peakFiltering = peakFiltering;
+    }
+
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
+    }
+
+    @Override
+    public float getFragmentIonTolerance() {
+        return fragmentIonTolerance;
     }
 }

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScore.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScore.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.pride.spectracluster.similarity;
 import org.apache.commons.math3.distribution.HypergeometricDistribution;
 import uk.ac.ebi.pride.spectracluster.spectrum.IPeak;
 import uk.ac.ebi.pride.spectracluster.spectrum.ISpectrum;
+import uk.ac.ebi.pride.spectracluster.util.Defaults;
 
 import java.util.List;
 
@@ -18,7 +19,6 @@ public class HypergeometricScore implements ISimilarityChecker {
     public static final String algorithmName = "Hypergeometric Exact Test";
     public static final String algorithmVersion = "0.1";
 
-    public static final float DEFAULT_PEAK_MZ_TOLERANCE = 0.5F;
     public static final boolean DEFAULT_PEAK_FILTERING = true;
 
     private boolean peakFiltering;
@@ -26,18 +26,18 @@ public class HypergeometricScore implements ISimilarityChecker {
     /**
      * The tolerance in m/z units used to match peaks
      */
-    protected float peakMzTolerance;
+    protected float fragmentIonTolerance;
 
     public HypergeometricScore() {
-        this(DEFAULT_PEAK_MZ_TOLERANCE, DEFAULT_PEAK_FILTERING);
+        this(Defaults.getFragmentIonTolerance(), DEFAULT_PEAK_FILTERING);
     }
 
-    public HypergeometricScore(float peakMzTolerance) {
-        this.peakMzTolerance = peakMzTolerance;
+    public HypergeometricScore(float fragmentIonTolerance) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
     }
 
-    public HypergeometricScore(float peakMzTolerance, boolean peakFiltering) {
-        this.peakMzTolerance = peakMzTolerance;
+    public HypergeometricScore(float fragmentIonTolerance, boolean peakFiltering) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
         this.peakFiltering = peakFiltering;
     }
 
@@ -74,7 +74,7 @@ public class HypergeometricScore implements ISimilarityChecker {
             maxMz = peaks2.get(peaks2.size() - 1).getMz();
         }
 
-        int numberOfBins = Math.round((maxMz - minMz) / peakMzTolerance);
+        int numberOfBins = Math.round((maxMz - minMz) / fragmentIonTolerance);
 
         // cannot be assessed
         if (numberOfBins < 1) {
@@ -110,7 +110,7 @@ public class HypergeometricScore implements ISimilarityChecker {
 
     @Override
     public double assessSimilarity(ISpectrum spectrum1, ISpectrum spectrum2) {
-        IPeakMatches peakMatches = PeakMatchesUtilities.getSharedPeaksAsMatches(spectrum1, spectrum2, peakMzTolerance, peakFiltering);
+        IPeakMatches peakMatches = PeakMatchesUtilities.getSharedPeaksAsMatches(spectrum1, spectrum2, fragmentIonTolerance, peakFiltering);
         return assessSimilarity(peakMatches);
     }
 
@@ -124,12 +124,14 @@ public class HypergeometricScore implements ISimilarityChecker {
         return algorithmVersion;
     }
 
-    public float getPeakMzTolerance() {
-        return peakMzTolerance;
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
     }
 
-    public void setPeakMzTolerance(float peakMzTolerance) {
-        this.peakMzTolerance = peakMzTolerance;
+    @Override
+    public float getFragmentIonTolerance() {
+        return fragmentIonTolerance;
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScoreDiffPopSize.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScoreDiffPopSize.java
@@ -1,8 +1,6 @@
 package uk.ac.ebi.pride.spectracluster.similarity;
 
-import org.apache.commons.math3.distribution.HypergeometricDistribution;
 import uk.ac.ebi.pride.spectracluster.spectrum.IPeak;
-import uk.ac.ebi.pride.spectracluster.spectrum.ISpectrum;
 
 import java.util.List;
 
@@ -17,12 +15,12 @@ public class HypergeometricScoreDiffPopSize extends HypergeometricScore {
     public HypergeometricScoreDiffPopSize() {
     }
 
-    public HypergeometricScoreDiffPopSize(float peakMzTolerance) {
-        super(peakMzTolerance);
+    public HypergeometricScoreDiffPopSize(float fragmentIonTolerance) {
+        super(fragmentIonTolerance);
     }
 
-    public HypergeometricScoreDiffPopSize(float peakMzTolerance, boolean peakFiltering) {
-        super(peakMzTolerance, peakFiltering);
+    public HypergeometricScoreDiffPopSize(float fragmentIonTolerance, boolean peakFiltering) {
+        super(fragmentIonTolerance, peakFiltering);
     }
 
     @Override
@@ -36,7 +34,7 @@ public class HypergeometricScoreDiffPopSize extends HypergeometricScore {
         float minMz = peaksSpectrumOne.get(0).getMz();
         float maxMz = peaksSpectrumOne.get(peaksSpectrumOne.size() - 1).getMz();
 
-        int numberOfBins = Math.round((maxMz - minMz) / peakMzTolerance);
+        int numberOfBins = Math.round((maxMz - minMz) / fragmentIonTolerance);
 
         return calculateSimilarityScore(peakMatches.getNumberOfSharedPeaks(),
                 peakMatches.getSpectrumOne().getPeaksCount(),

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/ISimilarityChecker.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/ISimilarityChecker.java
@@ -41,4 +41,16 @@ public interface ISimilarityChecker extends IAlgorithm {
      * @param peakFiltering
      */
     public void setPeakFiltering(boolean peakFiltering);
+
+    /**
+     * Set the used fragment ion tolerance used for peak matching between the two spectra.
+     * @param fragmentIonTolerance Fragment tolerance in m/z
+     */
+    public void setFragmentIonTolerance(float fragmentIonTolerance);
+
+    /**
+     * Returns the currently used fragment ion tolerance.
+     * @return The fragment ion tolerance in m/z
+     */
+    public float getFragmentIonTolerance();
 }

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/IntensityRankCorrelation.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/IntensityRankCorrelation.java
@@ -4,6 +4,7 @@ import org.apache.commons.math3.distribution.NormalDistribution;
 import org.apache.commons.math3.stat.correlation.KendallsCorrelation;
 import uk.ac.ebi.pride.spectracluster.spectrum.IPeak;
 import uk.ac.ebi.pride.spectracluster.spectrum.ISpectrum;
+import uk.ac.ebi.pride.spectracluster.util.Defaults;
 
 import java.util.List;
 
@@ -14,24 +15,26 @@ import java.util.List;
  * Created by jg on 23.02.15.
  */
 public class IntensityRankCorrelation implements ISimilarityChecker {
+    public final static boolean DEFAULT_PEAK_FILTERING = true;
+
     /**
      * The m/z tolerance to use in peak matching
      */
-    private float peakMzTolerance = 0.5F;
-    private boolean peakFiltering = true;
+    protected float fragmentIonTolerance;
+    protected boolean peakFiltering;
 
     private KendallsCorrelation kendallsCorrelation = new KendallsCorrelation();
 
     public IntensityRankCorrelation() {
-
+        this(Defaults.getFragmentIonTolerance(), DEFAULT_PEAK_FILTERING);
     }
 
-    public IntensityRankCorrelation(float peakMzTolerance) {
-        this.peakMzTolerance = peakMzTolerance;
+    public IntensityRankCorrelation(float fragmentIonTolerance) {
+        this(fragmentIonTolerance, DEFAULT_PEAK_FILTERING);
     }
 
-    public IntensityRankCorrelation(float peakMzTolerance, boolean peakFiltering) {
-        this.peakMzTolerance = peakMzTolerance;
+    public IntensityRankCorrelation(float fragmentIonTolerance, boolean peakFiltering) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
         this.peakFiltering = peakFiltering;
     }
 
@@ -68,7 +71,7 @@ public class IntensityRankCorrelation implements ISimilarityChecker {
 
     @Override
     public double assessSimilarity(ISpectrum spectrum1, ISpectrum spectrum2) {
-        IPeakMatches peakMatches = PeakMatchesUtilities.getSharedPeaksAsMatches(spectrum1, spectrum2, peakMzTolerance, peakFiltering);
+        IPeakMatches peakMatches = PeakMatchesUtilities.getSharedPeaksAsMatches(spectrum1, spectrum2, fragmentIonTolerance, peakFiltering);
 
         return assessSimilarity(peakMatches);
     }
@@ -101,5 +104,15 @@ public class IntensityRankCorrelation implements ISimilarityChecker {
     @Override
     public String getCurrentVersion() {
         return null;
+    }
+
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
+    }
+
+    @Override
+    public float getFragmentIonTolerance() {
+        return fragmentIonTolerance;
     }
 }

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/util/Defaults.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/util/Defaults.java
@@ -9,9 +9,7 @@ import uk.ac.ebi.pride.spectracluster.normalizer.IIntensityNormalizer;
 import uk.ac.ebi.pride.spectracluster.normalizer.TotalIntensityNormalizer;
 import uk.ac.ebi.pride.spectracluster.quality.IQualityScorer;
 import uk.ac.ebi.pride.spectracluster.quality.SignalToNoiseChecker;
-import uk.ac.ebi.pride.spectracluster.similarity.FisherExactTest;
 import uk.ac.ebi.pride.spectracluster.similarity.FrankEtAlDotProduct;
-import uk.ac.ebi.pride.spectracluster.similarity.HypergeometricScore;
 import uk.ac.ebi.pride.spectracluster.similarity.ISimilarityChecker;
 import uk.ac.ebi.pride.spectracluster.spectrum.IPeak;
 import uk.ac.ebi.pride.spectracluster.util.comparator.ClusterComparator;
@@ -32,7 +30,7 @@ public class Defaults {
 
     public static final int DEFAULT_NUMBER_COMPARED_PEAKS = 15;
 
-    public static final double DEFAULT_MZ_RANGE = 0.5;
+    public static final float DEFAULT_FRAGMENT_ION_TOLERANCE = 0.5F;
 
     /**
      * Defines the similarity threshold above which spectra are added
@@ -56,7 +54,7 @@ public class Defaults {
 
     private static int numberComparedPeaks = DEFAULT_NUMBER_COMPARED_PEAKS;
 
-    private static double similarityMZRange = DEFAULT_MZ_RANGE;
+    private static float fragmentIonTolerance = DEFAULT_FRAGMENT_ION_TOLERANCE;
 
     private static double retainThreshold = DEFAULT_RETAIN_THRESHOLD;
 
@@ -86,8 +84,8 @@ public class Defaults {
         return numberComparedPeaks;
     }
 
-    public static double getSimilarityMZRange() {
-        return similarityMZRange;
+    public static float getFragmentIonTolerance() {
+        return fragmentIonTolerance;
     }
 
     public static double getRetainThreshold() {
@@ -106,8 +104,8 @@ public class Defaults {
         Defaults.numberComparedPeaks = numberComparedPeaks;
     }
 
-    public static void setSimilarityMZRange(double similarityMZRange) {
-        Defaults.similarityMZRange = similarityMZRange;
+    public static void setFragmentIonTolerance(float fragmentIonTolerance) {
+        Defaults.fragmentIonTolerance = fragmentIonTolerance;
     }
 
     /**
@@ -168,8 +166,8 @@ public class Defaults {
     }
 
 
-    private static ISimilarityChecker defaultSimilarityChecker = new FrankEtAlDotProduct(getSimilarityMZRange(), getNumberComparedPeaks());
-    //private static ISimilarityChecker defaultSimilarityChecker = new FisherExactTest((float) getSimilarityMZRange());
+    private static ISimilarityChecker defaultSimilarityChecker = new FrankEtAlDotProduct(getFragmentIonTolerance(), getNumberComparedPeaks());
+    //private static ISimilarityChecker defaultSimilarityChecker = new FisherExactTest((float) getFragmentIonTolerance());
 
     public static ISimilarityChecker getDefaultSimilarityChecker() {
         return defaultSimilarityChecker;

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/consensus/ConsensusSpectrumBuilderComparisonMain.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/consensus/ConsensusSpectrumBuilderComparisonMain.java
@@ -70,7 +70,7 @@ public class ConsensusSpectrumBuilderComparisonMain {
         ISpectrum filteredConsensusSpectrum = builder.getConsensusSpectrum();
 
         // compare the spectra
-        final AllPeaksDotProduct allPeaksDotProduct = new AllPeaksDotProduct(Defaults.getSimilarityMZRange());
+        final AllPeaksDotProduct allPeaksDotProduct = new AllPeaksDotProduct(Defaults.getFragmentIonTolerance());
 
         final double similarity = allPeaksDotProduct.assessSimilarity(unfilteredConsensusSpectrum, filteredConsensusSpectrum);
 

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/consensus/ConsensusSpectrumBuilderComparisonTests.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/consensus/ConsensusSpectrumBuilderComparisonTests.java
@@ -54,7 +54,7 @@ public class ConsensusSpectrumBuilderComparisonTests {
         ISpectrum filteredConsensusSpectrum = builder.getConsensusSpectrum();
 
         // compare the spectra
-        final AllPeaksDotProduct allPeaksDotProduct = new AllPeaksDotProduct(Defaults.getSimilarityMZRange());
+        final AllPeaksDotProduct allPeaksDotProduct = new AllPeaksDotProduct(Defaults.getFragmentIonTolerance());
 
         final double similarity = allPeaksDotProduct.assessSimilarity(unfilteredConsensusSpectrum, filteredConsensusSpectrum);
         Assert.assertTrue("Consensus spectra must be similar (" + similarity + ")", similarity >= 0.92);

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/consensus/ConsensusSpectrumBuilderTests.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/consensus/ConsensusSpectrumBuilderTests.java
@@ -74,7 +74,7 @@ public class ConsensusSpectrumBuilderTests {
         ISpectrum originalSpec = originalConsensusSpectrumBuilder.getConsensusSpectrum();
         ISpectrum currentSpec = currentConsensusSpectrumBuilder.getConsensusSpectrum();
 
-        ISimilarityChecker similarityChecker = new FrankEtAlDotProduct(0.1, 15);
+        ISimilarityChecker similarityChecker = new FrankEtAlDotProduct(0.1F, 15);
 
         double dotProduct = similarityChecker.assessSimilarity(originalSpec, currentSpec);
 

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/AllPeaksDotProductTest.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/AllPeaksDotProductTest.java
@@ -19,8 +19,8 @@ public class AllPeaksDotProductTest {
 
     @Before
     public void setUp() {
-        allPeaksDotProduct = new AllPeaksDotProduct(Defaults.getSimilarityMZRange());
-        frankEtAlDotProduct = new FrankEtAlDotProduct(Defaults.getSimilarityMZRange(), Defaults.getNumberComparedPeaks());
+        allPeaksDotProduct = new AllPeaksDotProduct(Defaults.getFragmentIonTolerance());
+        frankEtAlDotProduct = new FrankEtAlDotProduct(Defaults.getFragmentIonTolerance(), Defaults.getNumberComparedPeaks());
         testSpectra = ClusteringTestUtilities.readISpectraFromResource();
     }
 

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/ClosestPeaksTest.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/ClosestPeaksTest.java
@@ -42,7 +42,7 @@ public class ClosestPeaksTest {
         ISpectrum[] spectrums = (ISpectrum[]) spectra.toArray();
 
         ISimilarityChecker checker = new FrankEtAlDotProductTester();
-        ISimilarityChecker currentChecker = new FrankEtAlDotProduct(0.5, 15);
+        ISimilarityChecker currentChecker = new FrankEtAlDotProduct(0.5F, 15);
 
         //noinspection UnnecessaryLocalVariable,UnusedDeclaration,UnusedAssignment
         Set<String> interestingIds = new HashSet<String>();
@@ -96,7 +96,7 @@ public class ClosestPeaksTest {
 
         int total = 0;
         int different = 0;
-        ISimilarityChecker checker = new FrankEtAlDotProduct(0.5, 15);
+        ISimilarityChecker checker = new FrankEtAlDotProduct(0.5F, 15);
         ISimilarityChecker currentChecker = new FrankEtAlDotProductJohannes();
 
         Set<String> interestingIds = new HashSet<String>();

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProductJohannes.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProductJohannes.java
@@ -81,7 +81,7 @@ public class FrankEtAlDotProductJohannes implements ISimilarityChecker {
         return getVersion().toString();
     }
 
-    private double mzRange = Defaults.getSimilarityMZRange();
+    private double mzRange = Defaults.getFragmentIonTolerance();
     /**
      * The algorithm version to use. By
      * default the version described in
@@ -305,5 +305,15 @@ public class FrankEtAlDotProductJohannes implements ISimilarityChecker {
     @Override
     public void setPeakFiltering(boolean peakFiltering) {
 
+    }
+
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+
+    }
+
+    @Override
+    public float getFragmentIonTolerance() {
+        return 0;
     }
 }

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProductOld.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProductOld.java
@@ -294,4 +294,14 @@ public class FrankEtAlDotProductOld implements ISimilarityChecker {
     public void setPeakFiltering(boolean peakFiltering) {
 
     }
+
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+
+    }
+
+    @Override
+    public float getFragmentIonTolerance() {
+        return 0;
+    }
 }

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProductTester.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FrankEtAlDotProductTester.java
@@ -305,4 +305,14 @@ public class FrankEtAlDotProductTester implements ISimilarityChecker {
     public void setPeakFiltering(boolean peakFiltering) {
 
     }
+
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+
+    }
+
+    @Override
+    public float getFragmentIonTolerance() {
+        return 0;
+    }
 }

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/TestSimilarityMethods.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/TestSimilarityMethods.java
@@ -565,7 +565,7 @@ public class TestSimilarityMethods {
     @Test
     public void testSimilarity() throws Exception {
         ISimilarityChecker oldSimilarity = new FrankEtAlDotProductOld();
-        ISimilarityChecker newSimilarity = new FrankEtAlDotProduct(0.5, 15);
+        ISimilarityChecker newSimilarity = new FrankEtAlDotProduct(0.5F, 15);
 
         double oldDP = oldSimilarity.assessSimilarity(spectrum1, spectrum2);
         double newDP = newSimilarity.assessSimilarity(spectrum1, spectrum2);
@@ -583,7 +583,7 @@ public class TestSimilarityMethods {
     public void testSelfSimilarity() throws Exception {
 
         ISimilarityChecker oldSimilarity = new FrankEtAlDotProductOld();
-        ISimilarityChecker newSimilarity = new FrankEtAlDotProduct(0.5, 15);
+        ISimilarityChecker newSimilarity = new FrankEtAlDotProduct(0.5F, 15);
 
         double toSelf = oldSimilarity.assessSimilarity(spectrum1, spectrum1);
         Assert.assertEquals(1, toSelf, 0);
@@ -599,7 +599,7 @@ public class TestSimilarityMethods {
         List<ISpectrum> spectra = ClusteringTestUtilities.readISpectraFromResource();
 
         ISimilarityChecker oldSimilarity = new FrankEtAlDotProductOld();
-        ISimilarityChecker newSimilarity = new FrankEtAlDotProduct(0.5, 15);
+        ISimilarityChecker newSimilarity = new FrankEtAlDotProduct(0.5F, 15);
 
         for (ISpectrum s1 : spectra) {
             for (ISpectrum s2 : spectra) {

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/util/ClusteringUtilitiesTests.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/util/ClusteringUtilitiesTests.java
@@ -23,7 +23,7 @@ public class ClusteringUtilitiesTests {
 //        // add the second list to the first making duplicates
 //        list1.addAll(list2); // dupicate clusters
 //
-//        final ISimilarityChecker similarityChecker = new FrankEtAlDotProduct(Defaults.getSimilarityMZRange(), Defaults.getNumberComparedPeaks());
+//        final ISimilarityChecker similarityChecker = new FrankEtAlDotProduct(Defaults.getFragmentIonTolerance(), Defaults.getNumberComparedPeaks());
 //        // now merge - should get less or equal to original list
 //        final List<ICluster> newClusters = ClusterUtilities.mergeClusters(new ArrayList<ICluster>(list1), similarityChecker, 1);
 //        // we merge at least as many as we had
@@ -67,7 +67,7 @@ public class ClusteringUtilitiesTests {
 //        List<ICluster> found = (List<ICluster>) engine.getClusters();
 //
 //
-//        final ISimilarityChecker similarityChecker = new FrankEtAlDotProduct(Defaults.getSimilarityMZRange(), Defaults.getNumberComparedPeaks());
+//        final ISimilarityChecker similarityChecker = new FrankEtAlDotProduct(Defaults.getFragmentIonTolerance(), Defaults.getNumberComparedPeaks());
 //        final List<ICluster> newClusters = ClusterUtilities.mergeClusters(found, similarityChecker, 1);
 //
 //        // because we just did this in the engine we expect little further merging


### PR DESCRIPTION
Updated the ISimilarityCheckerInterface to include a getter / setter for fragment ion tolerance.
Renamed all variables to 'fragmentIonTolerance' for consistency reasons with (most) search engines.
Removed all default values from the respective classes and updated them to use the default value set by Defaults.