### PR TITLE
Fisher - Int rank Combined test

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/CombinedFisherIntensityTest.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/CombinedFisherIntensityTest.java
@@ -1,0 +1,107 @@
+package uk.ac.ebi.pride.spectracluster.similarity;
+
+import org.apache.commons.math3.distribution.ChiSquaredDistribution;
+import uk.ac.ebi.pride.spectracluster.spectrum.ISpectrum;
+import uk.ac.ebi.pride.spectracluster.util.Defaults;
+
+/**
+ * This SimilarityChecker combines the probability of the
+ * FisherExactTest and the IntensityRankCorrelation Test
+ * using Fisher's method to combine extreme probabilities.
+ *
+ * Created by jg on 15.04.15.
+ */
+public class CombinedFisherIntensityTest implements ISimilarityChecker {
+    public static final String algorithmName = "Combined FisherExact and Intensity rank test";
+    public static final String algorithmVersion = "0.1";
+
+    /**
+     * These classes will be used to calculate the FisherExactTest and
+     * IntensityRank probability.
+     *
+     * In both cases the IPeakMatches version of assessSimilarity
+     * is used. Therefore, the fragmentIonTolerance and peakFiltering
+     * do not have to be set.
+      */
+    protected final FisherExactTest fisherExactTest = new FisherExactTest();
+    protected final IntensityRankCorrelation intensityRankCorrelation = new IntensityRankCorrelation();
+    protected final ChiSquaredDistribution chiSquaredDistribution = new ChiSquaredDistribution(4); // always 4 degrees of freedom
+
+    /**
+     * The tolerance in m/z units used to match peaks
+     */
+    protected float fragmentIonTolerance;
+
+    public static final boolean DEFAULT_PEAK_FILTERING = true;
+
+    private boolean peakFiltering;
+
+    public CombinedFisherIntensityTest() {
+        this(Defaults.getFragmentIonTolerance());
+    }
+
+    public CombinedFisherIntensityTest(float fragmentIonTolerance) {
+        this(fragmentIonTolerance, DEFAULT_PEAK_FILTERING);
+    }
+
+    public CombinedFisherIntensityTest(float fragmentIonTolerance, boolean peakFiltering) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
+        this.peakFiltering = peakFiltering;
+    }
+
+    @Override
+    public double assessSimilarity(ISpectrum spectrum1, ISpectrum spectrum2) {
+        IPeakMatches peakMatches = PeakMatchesUtilities.getSharedPeaksAsMatches(spectrum1, spectrum2, fragmentIonTolerance, peakFiltering);
+        return assessSimilarity(peakMatches);
+    }
+
+    @Override
+    public double assessSimilarity(IPeakMatches peakMatches) {
+        double fisherExactP = fisherExactTest.assessSimilarityAsPValue(peakMatches);
+        double intensityRankP = intensityRankCorrelation.assessSimilarityAsPValue(peakMatches);
+
+        // combine the p-values using Fisher's method
+        double combined = -2 * (Math.log(fisherExactP) + Math.log(intensityRankP));
+        double pValue;
+
+        if (combined == 0)
+            return 0;
+
+        if (Double.isInfinite(combined))
+            pValue = 0;
+        else
+            pValue = chiSquaredDistribution.density(combined); // TODO: this is not the correct implementation!
+
+        return -Math.log(pValue);
+    }
+
+    @Override
+    public boolean isPeakFiltering() {
+        return peakFiltering;
+    }
+
+    @Override
+    public void setPeakFiltering(boolean peakFiltering) {
+        this.peakFiltering = peakFiltering;
+    }
+
+    @Override
+    public void setFragmentIonTolerance(float fragmentIonTolerance) {
+        this.fragmentIonTolerance = fragmentIonTolerance;
+    }
+
+    @Override
+    public float getFragmentIonTolerance() {
+        return fragmentIonTolerance;
+    }
+
+    @Override
+    public String getName() {
+        return algorithmName;
+    }
+
+    @Override
+    public String getCurrentVersion() {
+        return algorithmVersion;
+    }
+}

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/FisherExactTest.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/FisherExactTest.java
@@ -26,9 +26,9 @@ public class FisherExactTest extends HypergeometricScore {
     }
 
     @Override
-    protected double calculateSimilarityScore(int numberOfSharedPeaks, int numberOfPeaksFromSpec1, int numberOfPeaksFromSpec2, int numberOfBins) {
+    protected double calculateSimilarityProbablity(int numberOfSharedPeaks, int numberOfPeaksFromSpec1, int numberOfPeaksFromSpec2, int numberOfBins) {
         if (numberOfBins < 1) {
-            return 0;
+            return 1;
         }
 
         HypergeometricDistribution hypergeometricDistribution = new HypergeometricDistribution(
@@ -38,10 +38,10 @@ public class FisherExactTest extends HypergeometricScore {
         double hgtScore = hypergeometricDistribution.probability(numberOfSharedPeaks);
 
         if (hgtScore == 0) {
-            return 0;
+            return 1;
         }
 
-        return -Math.log(hgtScore);
+        return hgtScore;
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScore.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScore.java
@@ -56,6 +56,19 @@ public class HypergeometricScore implements ISimilarityChecker {
                 numberOfBins);
     }
 
+    public double assessSimilarityAsPValue(IPeakMatches peakMatches) {
+        // if there are no shared peaks, return 0 to indicate that it's random
+        if (peakMatches.getNumberOfSharedPeaks() < 1)
+            return 1;
+
+        int numberOfBins = calculateNumberOfBins(peakMatches);
+
+        return calculateSimilarityProbablity(peakMatches.getNumberOfSharedPeaks(),
+                peakMatches.getSpectrumOne().getPeaksCount(),
+                peakMatches.getSpectrumTwo().getPeaksCount(),
+                numberOfBins);
+    }
+
     protected int calculateNumberOfBins(IPeakMatches peakMatches) {
         List<IPeak> peaks1 = peakMatches.getSpectrumOne().getPeaks();
         List<IPeak> peaks2 = peakMatches.getSpectrumTwo().getPeaks();
@@ -89,9 +102,9 @@ public class HypergeometricScore implements ISimilarityChecker {
         return numberOfBins;
     }
 
-    protected double calculateSimilarityScore(int numberOfSharedPeaks, int numberOfPeaksFromSpec1, int numberOfPeaksFromSpec2, int numberOfBins) {
+    protected double calculateSimilarityProbablity(int numberOfSharedPeaks, int numberOfPeaksFromSpec1, int numberOfPeaksFromSpec2, int numberOfBins) {
         if (numberOfBins < 1) {
-            return 0;
+            return 1;
         }
 
         // ToDo: @jgriss In peptidome manuscript, the number of successes and the sample size are the same, was it a mistake from them?
@@ -103,10 +116,16 @@ public class HypergeometricScore implements ISimilarityChecker {
         }
 
         if (hgtScore == 0) {
-            return 0;
+            return 1;
         }
 
-        return -Math.log(hgtScore);
+        return hgtScore;
+    }
+
+    protected double calculateSimilarityScore(int numberOfSharedPeaks, int numberOfPeaksFromSpec1, int numberOfPeaksFromSpec2, int numberOfBins) {
+        double pValue = calculateSimilarityProbablity(numberOfSharedPeaks, numberOfPeaksFromSpec1, numberOfPeaksFromSpec2, numberOfBins);
+
+        return -Math.log(pValue);
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScore.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/similarity/HypergeometricScore.java
@@ -34,6 +34,7 @@ public class HypergeometricScore implements ISimilarityChecker {
 
     public HypergeometricScore(float fragmentIonTolerance) {
         this.fragmentIonTolerance = fragmentIonTolerance;
+        this.peakFiltering = DEFAULT_PEAK_FILTERING;
     }
 
     public HypergeometricScore(float fragmentIonTolerance, boolean peakFiltering) {

--- a/src/main/java/uk/ac/ebi/pride/spectracluster/util/function/peak/RankAsIntensityFunction.java
+++ b/src/main/java/uk/ac/ebi/pride/spectracluster/util/function/peak/RankAsIntensityFunction.java
@@ -1,0 +1,42 @@
+package uk.ac.ebi.pride.spectracluster.util.function.peak;
+
+import uk.ac.ebi.pride.spectracluster.spectrum.IPeak;
+import uk.ac.ebi.pride.spectracluster.spectrum.Peak;
+import uk.ac.ebi.pride.spectracluster.util.function.IFunction;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This function replaces the peaks' intensities by their rank. The
+ * highest peak gets the intensity of the number of peaks (if there are
+ * 50 peaks, the highest peak gets intensity 50, the second highest 49
+ * and so on). This is based on the method used in
+ * Shao W, Zhu K, Lam H., Proteomics. 2013 Nov;13(22):3273-83
+ *
+ * Created by jg on 18.04.15.
+ */
+public class RankAsIntensityFunction implements IFunction<List<IPeak>, List<IPeak>> {
+    @Override
+    public List<IPeak> apply(List<IPeak> peaks) {
+        List<Float> intensities = new ArrayList<Float>(peaks.size());
+
+        for (IPeak p : peaks) {
+            intensities.add(p.getIntensity());
+        }
+
+        Collections.sort(intensities);
+
+        List<IPeak> changedPeaks = new ArrayList<IPeak>(peaks.size());
+
+        for (IPeak p : peaks) {
+            // get the rank
+            int rank = intensities.indexOf(p.getIntensity()) + 1;
+
+            changedPeaks.add(new Peak(p.getMz(), rank, p.getCount()));
+        }
+
+        return changedPeaks;
+    }
+}

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FisherExactTestTest.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FisherExactTestTest.java
@@ -126,14 +126,16 @@ public class FisherExactTestTest {
          * n = 5
          * HypergeometricScore: 11404 msec, 9308 msec, 9670 msec
          * Fisher Exact Test: Took: 4230 msec, 3570 msec, 3627 msec
-         * Dot Product (new version): 432 msec, 109 msec, 108 msec
+         * Dot Product (new version): 432 msec, 109 msec, 108 msec   (300 - 500)
+         * Combined version: 11-14 sec(!)
+         * Fisher Exact (second test): 9199, 4532, 6894
          */
 
 
         int nRounds = 5;
         int nTimes = 3;
 
-        ISimilarityChecker similarityChecker = new FisherExactTest();
+        ISimilarityChecker similarityChecker = new FisherExactTest(0.5F);
         long[] duration = new long[nTimes];
 
         for (int time = 0; time < nTimes; time++) {

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FisherExactTestTest.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/similarity/FisherExactTestTest.java
@@ -127,15 +127,20 @@ public class FisherExactTestTest {
          * HypergeometricScore: 11404 msec, 9308 msec, 9670 msec
          * Fisher Exact Test: Took: 4230 msec, 3570 msec, 3627 msec
          * Dot Product (new version): 432 msec, 109 msec, 108 msec   (300 - 500)
+         *
+         * -- changed CPU settings on my machine - slower now --
          * Combined version: 11-14 sec(!)
-         * Fisher Exact (second test): 9199, 4532, 6894
+         * Fisher Exact: ~3500 msec
+         * Hypergeometric: ~4300 msec
+         * Dot: ~100-130 msec
+         * Combined: 6500 msec
          */
 
 
         int nRounds = 5;
-        int nTimes = 3;
+        int nTimes = 4;
 
-        ISimilarityChecker similarityChecker = new FisherExactTest(0.5F);
+        ISimilarityChecker similarityChecker = new HypergeometricScore(0.5F);
         long[] duration = new long[nTimes];
 
         for (int time = 0; time < nTimes; time++) {

--- a/src/test/java/uk/ac/ebi/pride/spectracluster/util/function/peak/RankAsIntensityFunctionTest.java
+++ b/src/test/java/uk/ac/ebi/pride/spectracluster/util/function/peak/RankAsIntensityFunctionTest.java
@@ -1,0 +1,38 @@
+package uk.ac.ebi.pride.spectracluster.util.function.peak;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import uk.ac.ebi.pride.spectracluster.spectrum.IPeak;
+import uk.ac.ebi.pride.spectracluster.spectrum.Peak;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by jg on 18.04.15.
+ */
+public class RankAsIntensityFunctionTest {
+    private RankAsIntensityFunction rankAsIntensityFunction = new RankAsIntensityFunction();
+
+    @Test
+    public void testIntensityConversion() {
+        List<IPeak> testPeakList = new ArrayList<IPeak>(5);
+
+        IPeak p1 = new Peak(1F, 20F);
+        IPeak p2 = new Peak(2F, 30F);
+        IPeak p3 = new Peak(3F, 40F);
+        IPeak p4 = new Peak(4F, 50F);
+
+        testPeakList.add(p3);
+        testPeakList.add(p2);
+        testPeakList.add(p1);
+        testPeakList.add(p4);
+
+        List<IPeak> convertedPeaks = rankAsIntensityFunction.apply(testPeakList);
+
+        Assert.assertEquals(3F, convertedPeaks.get(0).getIntensity());
+        Assert.assertEquals(2F, convertedPeaks.get(1).getIntensity());
+        Assert.assertEquals(1F, convertedPeaks.get(2).getIntensity());
+        Assert.assertEquals(4F, convertedPeaks.get(3).getIntensity());
+    }
+}


### PR DESCRIPTION
Added a new SimilarityChecker that combines the p-values from the FisherExact test and the IntensityRank test using [Fisher's method](https://en.wikipedia.org/wiki/Fisher%27s_method).
One unresolved issue is that Fisher's method is not implemented completely correctly: currently, only the point probability (using the _density_ function) is calculated since the required combined probability (*P[X > x]*) is not supported by the implementation available from math.commons.
The actual difference in marginal. The correct implementation (tested using R) provides a little more conservative estimates.